### PR TITLE
Fix detection of numeric value when parsing short options

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = function (args, opts) {
 
 				if (
 					(/[A-Za-z]/).test(letters[j])
-					&& (/-?\d+(\.\d*)?(e-?\d+)?$/).test(next)
+					&& (/^-?\d+(\.\d*)?(e-?\d+)?$/).test(next)
 				) {
 					setArg(letters[j], next, arg);
 					broken = true;

--- a/test/short.js
+++ b/test/short.js
@@ -12,6 +12,11 @@ test('numeric short args', function (t) {
 	);
 });
 
+test('partial numeric short args', function (t) {
+	t.plan(1);
+	t.deepEqual(parse(['-n1b3']), { n: true, 1: true, b: 3, _: [] });
+});
+
 test('short', function (t) {
 	t.deepEqual(
 		parse(['-b']),


### PR DESCRIPTION
## Problem

The parsing behaviour changes depending on whether the last character in group is a number, switching between a group of boolean options and an option taking a value. See https://github.com/minimistjs/minimist/issues/2#issue-1410232307

For example:
```console
$ node example/parse.js -a1
{ _: [], a: 1 }

$ node example/parse.js -a1b
{ '1': true, _: [], a: true, b: true }

$ node example/parse.js -a1b2
{ _: [], a: '1b2' }

$ node example/parse.js -a1b2c
{ '1': true, '2': true, _: [], a: true, b: true, c: true }
```

## Solution

Per https://github.com/minimistjs/minimist/issues/2#issuecomment-1279821340

There is a bug in the code detecting whether the remaining characters in the argument are a number. If the argument ends in a number it is treated as a number, even if there are letters before that.

The search `/-?\d+(\.\d*)?(e-?\d+)?$/` is not anchored at the start and thinks `1b2` is a number because it ends in a number. So it treats `-a1b2` like `-a123` and assigns the "number" to the `a` option.
