### PR TITLE
Fix short option with an embedded `=` later in the argument 

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,8 +189,8 @@ module.exports = function (args, opts) {
 					continue;
 				}
 
-				if ((/[A-Za-z]/).test(letters[j]) && (/[=]/).test(next)) {
-					setArg(letters[j], next.split('=')[1], arg);
+				if ((/[A-Za-z]/).test(letters[j]) && next[0] === '=') {
+					setArg(letters[j], next.slice(1), arg);
 					broken = true;
 					break;
 				}

--- a/test/kv_short.js
+++ b/test/kv_short.js
@@ -16,3 +16,17 @@ test('multi short -k=v', function (t) {
 	var argv = parse(['-a=whatever', '-b=robots']);
 	t.deepEqual(argv, { a: 'whatever', b: 'robots', _: [] });
 });
+
+test('short with embedded equals -k=a=b', function (t) {
+	t.plan(1);
+
+	var argv = parse(['-k=a=b']);
+	t.deepEqual(argv, { k: 'a=b', _: [] });
+});
+
+test('short with later equals like -ab=c', function (t) {
+	t.plan(1);
+
+	var argv = parse(['-ab=c']);
+	t.deepEqual(argv, { a: true, b: 'c', _: [] });
+});


### PR DESCRIPTION
## Problem

A short option with an embedded `=` later in the argument is parsed inconsistently and with data loss.

In particular:

`-a=b=c` gives same result as `-a=b` (lost trailing `=c`)

`-ab=c` gives same result as `-a=c` (lost leading `b`)

Fixes #5

## Solution

Make code more explicit and test for `=` at start when looking for possible value.

`-a=b=c` makes option `a` have value `b=c`.

`-ab=c` makes option `a` true and option `b` have value `c`. 

(In my first commit I made `-ab=c` give option `b` the value `=c` by only treating the `=` as special at the start. I checked Yargs and found it set value to `c`. I can see a rationale for the parsing to treat it like an expansion, so `-ab=c` => `-a` `-b=c`, and option `b` has value `c`. More comfortable matching Yargs with this behaviour.)