### PR TITLE
integrate typings + nodenext

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,30 @@
+name: 'Typescript'
+on:
+  push:
+    paths:
+      - "types/**"
+  pull_request:
+    paths:
+      - "types/**"
+
+permissions:
+  contents: read
+jobs:
+  typescript:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+      - name: Test typings
+        run: |
+          npm run typescript

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function isConstructorOrProto(obj, key) {
 	return (key === 'constructor' && typeof obj[key] === 'function') || key === '__proto__';
 }
 
-module.exports = function (args, opts) {
+function minimist(args, opts) {
 	if (!opts) { opts = {}; }
 
 	var flags = {
@@ -260,4 +260,8 @@ module.exports = function (args, opts) {
 	}
 
 	return argv;
-};
+}
+
+module.exports = minimist;
+module.exports.default = minimist;
+module.exports.minimist = minimist;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "1.2.7",
 	"description": "parse argument options",
 	"main": "index.js",
+	"types": "types/index.d.ts",
 	"devDependencies": {
 		"@ljharb/eslint-config": "^21.0.0",
 		"aud": "^2.0.1",
@@ -12,7 +13,8 @@
 		"npmignore": "^0.3.0",
 		"nyc": "^10.3.2",
 		"safe-publish-latest": "^2.0.0",
-		"tape": "^5.6.1"
+		"tape": "^5.6.1",
+		"tsd": "^0.25.0"
 	},
 	"scripts": {
 		"prepack": "npmignore --auto --commentLines=auto",
@@ -22,6 +24,7 @@
 		"pretest": "npm run lint",
 		"tests-only": "nyc tape 'test/**/*.js'",
 		"test": "npm run tests-only",
+		"typescript": "tsd",
 		"posttest": "aud --production",
 		"version": "auto-changelog && git add CHANGELOG.md",
 		"postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,108 @@
+// Type definitions for minimist 1.2
+// Project: https://github.com/substack/minimist
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+//                 Necroskillz <https://github.com/Necroskillz>
+//                 kamranayub <https://github.com/kamranayub>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type Minimist = typeof minimist
+
+declare namespace minimist {
+  export interface Opts {
+    /**
+     * A string or array of strings argument names to always treat as strings
+     */
+    string?: string | string[] | undefined;
+
+    /**
+     * A boolean, string or array of strings to always treat as booleans. If true will treat
+     * all double hyphenated arguments without equals signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
+     */
+    boolean?: boolean | string | string[] | undefined;
+
+    /**
+     * An object mapping string names to strings or arrays of string argument names to use as aliases
+     */
+    alias?: { [key: string]: string | string[] } | undefined;
+
+    /**
+     * An object mapping string argument names to default values
+     */
+    default?: { [key: string]: any } | undefined;
+
+    /**
+     * When true, populate argv._ with everything after the first non-option
+     */
+    stopEarly?: boolean | undefined;
+
+    /**
+     * A function which is invoked with a command line parameter not defined in the opts
+     * configuration object. If the function returns false, the unknown option is not added to argv
+     */
+    unknown?: ((arg: string) => boolean) | undefined;
+
+    /**
+     * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --.
+     * Note that with -- set, parsing for arguments still stops after the `--`.
+     */
+    '--'?: boolean | undefined;
+  }
+
+  export interface ParsedArgs {
+    [arg: string]: any;
+
+    /**
+     * If opts['--'] is true, populated with everything after the --
+     */
+    '--'?: string[] | undefined;
+
+    /**
+     * Contains all the arguments that didn't have an option associated with them
+     */
+    _: string[];
+  }
+
+  // named export
+  // import { minimist } from 'minimist'
+  // const { minimist } = require('minimist')
+  export const minimist: Minimist
+
+  // default export
+  // import minimist from 'minimist'
+  export { minimist as default }
+}
+
+/**
+ * Return an argument object populated with the array arguments from args
+ *
+ * @param [args] An optional argument array (typically `process.argv.slice(2)`)
+ * @param [opts] An optional options object to customize the parsing
+ */
+declare function minimist(args?: string[], opts?: minimist.Opts): minimist.ParsedArgs;
+
+/**
+ * Return an argument object populated with the array arguments from args. Strongly-typed
+ * to be the intersect of type T with minimist.ParsedArgs.
+ *
+ * `T` The type that will be intersected with minimist.ParsedArgs to represent the argument object
+ *
+ * @param [args] An optional argument array (typically `process.argv.slice(2)`)
+ * @param [opts] An optional options object to customize the parsing
+ */
+declare function minimist<T>(args?: string[], opts?: minimist.Opts): T & minimist.ParsedArgs;
+
+/**
+ * Return an argument object populated with the array arguments from args. Strongly-typed
+ * to be the the type T which should extend minimist.ParsedArgs
+ *
+ * `T` The type that extends minimist.ParsedArgs and represents the argument object
+ *
+ * @param [args] An optional argument array (typically `process.argv.slice(2)`)
+ * @param [opts] An optional options object to customize the parsing
+ */
+declare function minimist<T extends minimist.ParsedArgs>(args?: string[], opts?: minimist.Opts): T;
+
+// CJS export
+// const minimist = require('minimist')
+export = minimist;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,0 +1,60 @@
+import { expectType } from 'tsd';
+import minimist from '..';
+import { Opts, ParsedArgs } from '..';
+
+interface CustomArgs {
+    foo: boolean;
+}
+
+interface CustomArgs2 extends ParsedArgs {
+    foo: boolean;
+}
+
+const opts: Opts = {};
+expectType<string | string[] | undefined>(opts.string)
+opts.string = 'str';
+opts.string = ['strArr'];
+expectType<string | string[] | boolean | undefined>(opts.boolean)
+opts.boolean = true;
+opts.boolean = 'str';
+opts.boolean = ['strArr'];
+expectType<{ [key: string]: string | string[]; } | undefined>(opts.alias)
+opts.alias = {
+    foo: ['strArr'],
+};
+opts.alias = {
+    foo: 'str',
+};
+opts.default = {
+    foo: 'str',
+};
+opts.default = {
+    foo: 0,
+};
+opts.unknown = (arg: string) => {
+    if (/xyz/.test(arg)) {
+        return true;
+    }
+
+    return false;
+};
+expectType<boolean | undefined>(opts.stopEarly)
+opts.stopEarly = true;
+expectType<boolean | undefined>(opts['--'])
+opts['--'] = true;
+
+minimist(); // $ExpectType ParsedArgs
+minimist(['--a.b', '22']); // $ExpectType ParsedArgs
+minimist(['--a.b', '22'], { default: { 'a.b': 11 }, alias: { 'a.b': 'aa.bb' } }); // $ExpectType ParsedArgs
+minimist<CustomArgs>(); // $ExpectType CustomArgs & ParsedArgs
+minimist<CustomArgs>(['--a.b', '22']); // $ExpectType CustomArgs & ParsedArgs
+minimist<CustomArgs>(['--a.b', '22'], { default: { 'a.b': 11 }, alias: { 'a.b': 'aa.bb' } }); // $ExpectType CustomArgs & ParsedArgs
+minimist<CustomArgs2>(); // $ExpectType CustomArgs2 & ParsedArgs
+minimist<CustomArgs2>(['--a.b', '22']); // $ExpectType CustomArgs2 & ParsedArgs
+minimist<CustomArgs2>(['--a.b', '22'], { default: { 'a.b': 11 }, alias: { 'a.b': 'aa.bb' } }); // $ExpectType CustomArgs2 & ParsedArgs
+
+const obj = minimist<CustomArgs>(['--a.b', '22'], opts);
+expectType<CustomArgs & ParsedArgs>(obj)
+expectType<string[]>(obj._)
+expectType<number>(obj._.length)
+expectType<boolean>(obj.foo)


### PR DESCRIPTION
This PR integrates the typings for minimist from definetlytyped.
Using tsd for typings tests + improved tests
typings are nodenext compatible by applying principles from 