### PR TITLE
Fix long option followed by single dash

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ module.exports = function (args, opts) {
 			next = args[i + 1];
 			if (
 				next !== undefined
-				&& !(/^-/).test(next)
+				&& !(/^(-|--)[^-]/).test(next)
 				&& !flags.bools[key]
 				&& !flags.allBools
 				&& (aliases[key] ? !aliasIsBoolean(key) : true)

--- a/test/dash.js
+++ b/test/dash.js
@@ -4,8 +4,9 @@ var parse = require('../');
 var test = require('tape');
 
 test('-', function (t) {
-	t.plan(5);
+	t.plan(6);
 	t.deepEqual(parse(['-n', '-']), { n: '-', _: [] });
+	t.deepEqual(parse(['--nnn', '-']), { nnn: '-', _: [] });
 	t.deepEqual(parse(['-']), { _: ['-'] });
 	t.deepEqual(parse(['-f-']), { f: '-', _: [] });
 	t.deepEqual(
@@ -31,3 +32,12 @@ test('move arguments after the -- into their own `--` array', function (t) {
 		{ name: 'John', _: ['before'], '--': ['after'] }
 	);
 });
+
+test('--- option value', function (t) {
+	// A multi-dash value is largely an edge case, but check the behaviour is as expected,
+	// and in particular the same for short option and long option (as made consistent in Jan 2023).
+	t.plan(2);
+	t.deepEqual(parse(['-n', '---']), { n: '---', _: [] });
+	t.deepEqual(parse(['--nnn', '---']), { nnn: '---', _: [] });
+});
+


### PR DESCRIPTION
A single dash is used with some utilities to represent stdin/stdout, as an argument or as an option value. Minimist was allowing a single dash as a space-separated value for a short option but not for a long option.

Fixes #15

This PR uses the same pattern for checking a potential long-option value as already being used for checking the short-option value. In particular, this means a single dash is now accepted as an option value when used like:

```
util --foo -
```
