### PR TITLE
Ignore numeric-looking strings with huge values

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function hasKey(obj, keys) {
 
 function isNumber(x) {
 	if (typeof x === 'number') { return true; }
+	if (!Number.isSafeInteger(Math.floor(x))) { return false; }
 	if ((/^0x[0-9a-f]+$/i).test(x)) { return true; }
 	return (/^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/).test(x);
 }

--- a/test/num.js
+++ b/test/num.js
@@ -10,7 +10,9 @@ test('nums', function (t) {
 		'-z', '1e7',
 		'-w', '10f',
 		'--hex', '0xdeadbeef',
+		'--id', '1234e5678',
 		'789',
+		'1234e5678',
 	]);
 	t.deepEqual(argv, {
 		x: 1234,
@@ -18,14 +20,17 @@ test('nums', function (t) {
 		z: 1e7,
 		w: '10f',
 		hex: 0xdeadbeef,
-		_: [789],
+		id: '1234e5678',
+		_: [789, '1234e5678'],
 	});
 	t.deepEqual(typeof argv.x, 'number');
 	t.deepEqual(typeof argv.y, 'number');
 	t.deepEqual(typeof argv.z, 'number');
 	t.deepEqual(typeof argv.w, 'string');
 	t.deepEqual(typeof argv.hex, 'number');
+	t.deepEqual(typeof argv.id, 'string');
 	t.deepEqual(typeof argv._[0], 'number');
+	t.deepEqual(typeof argv._[1], 'string');
 	t.end();
 });
 


### PR DESCRIPTION
An issue people encounter using minimist (as reported on old repository) is that false-positive numeric-looking strings are unexpectedly converted to numbers with data loss, whether losing precision or being converted to `infinity`. For example,  values for twitter or YouTube ids.

The README says:

> Numeric-looking arguments will be returned as numbers unless opts.string or opts.boolean is set for that argument name.

The suggested author work-around of explicitly setting the option parsing does avoid the automatic number conversion for options, but this approach is not available for positional arguments.

A possible improvement is to follow the lead of yargs and not attempt to coerce numeric-looking strings which are too big to reasonably represent: https://github.com/yargs/yargs-parser/pull/110

(This only addresses one issue with automatic numeric conversion, and I don't mind if we leave it out and keep it simple! I had seen the issue reported and wanted to look into the problem, and how the code had evolved in Yargs which I knew had added some extra checks.)