### PR TITLE
Avoid 0.6 tests due to build failures

### DIFF
--- a/.github/workflows/node-aught.yml
+++ b/.github/workflows/node-aught.yml
@@ -9,7 +9,7 @@ jobs:
   tests:
     uses: ljharb/actions/.github/workflows/node.yml@main
     with:
-      range: '< 10'
+      range: '< 10 >= 0.7'
       type: minors
       command: npm run tests-only
 


### PR DESCRIPTION
Node.js 0.6 does not install and PR checks always fail . Expand range to avoid the failing installation.

Fixes #19

---

An alternative would be to disable 0.6 upstream, or fix! I'm opening a PR for a local solution/work-around.

I could open another issue in minimist to reenable 0.6 if/when fixed upstream? Reference: 
- https://github.com/ljharb/actions/issues/1