### PR TITLE
Robustness: rework isConstructorOrProto

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function isNumber(x) {
 }
 
 function isConstructorOrProto(obj, key) {
-	return key === 'constructor' && (typeof obj[key] === 'function' || key === '__proto__');
+	return (key === 'constructor' && typeof obj[key] === 'function') || key === '__proto__';
 }
 
 function hasKey(obj, keys) {
@@ -25,7 +25,7 @@ function setKey(obj, keys, value) {
 	var key;
 	for (var i = 0; i < keys.length - 1; i++) {
 		key = keys[i];
-		if (key === '__proto__' || isConstructorOrProto(o, key)) {
+		if (isConstructorOrProto(o, key)) {
 			return;
 		}
 		if (o[key] === undefined) { o[key] = {}; }
@@ -41,7 +41,7 @@ function setKey(obj, keys, value) {
 	}
 
 	key = keys[keys.length - 1];
-	if (key === '__proto__') { return; }
+	if (isConstructorOrProto(o, key)) { return; }
 	if (
 		o === Object.prototype
 		|| o === Number.prototype

--- a/test/proto.js
+++ b/test/proto.js
@@ -5,6 +5,20 @@ var test = require('tape');
 
 /* eslint no-proto: 0 */
 
+// Not pollution as such, but verify protections working as intended.
+test('trailing __proto__ key in dotted option ignored', function (t) {
+	var argv = parse(['--a.__proto__', 'IGNORED']);
+	t.deepEqual(argv.a, {});
+	t.end();
+});
+
+// Not pollution as such, but verify protections working as intended.
+test('trailing constructor key in dotted option ignored', function (t) {
+	var argv = parse(['--a.constructor', 'IGNORED']);
+	t.deepEqual(argv.a, {});
+	t.end();
+});
+
 test('proto pollution', function (t) {
 	var argv = parse(['--__proto__.x', '123']);
 	t.equal({}.x, undefined);


### PR DESCRIPTION
The `isConstructorOrProto` fix does not look right for the v0.2.x branch. I looked at various commits and suspect the back port of the fix itself went somewhat awry. This PR makes the code match the mainline.

Here are the relevant lines of code from the main branch and from the original commit and adapted commit adding `isConstructorOrProto`.

## Main line

- https://github.com/minimistjs/minimist/blob/6901ee286bc4c16da6830b48b46ce1574703cea1/index.js#L19-L21
- https://github.com/minimistjs/minimist/blob/6901ee286bc4c16da6830b48b46ce1574703cea1/index.js#L85
- https://github.com/minimistjs/minimist/blob/6901ee286bc4c16da6830b48b46ce1574703cea1/index.js#L99

## Original change

- https://github.com/minimistjs/minimist/blob/c2b981977fa834b223b408cfb860f933c9811e4d/index.js#L247-L249
- https://github.com/minimistjs/minimist/blob/c2b981977fa834b223b408cfb860f933c9811e4d/index.js#L73
- https://github.com/minimistjs/minimist/blob/c2b981977fa834b223b408cfb860f933c9811e4d/index.js#L82

## Adapted change (suspect)

- https://github.com/minimistjs/minimist/blob/ef9153fc52b6cea0744b2239921c5dcae4697f11/index.js#L9-L11
- https://github.com/minimistjs/minimist/blob/ef9153fc52b6cea0744b2239921c5dcae4697f11/index.js#L28-L30
- https://github.com/minimistjs/minimist/blob/ef9153fc52b6cea0744b2239921c5dcae4697f11/index.js#L44