### PR TITLE
Tests: check side-effects of pollution protection

### DIFF
--- a/test/proto.js
+++ b/test/proto.js
@@ -5,6 +5,20 @@ var test = require('tape');
 
 /* eslint no-proto: 0 */
 
+// Not pollution as such, but verify protections working as intended.
+test('trailing __proto__ in option key ignored', function (t) {
+	var argv = parse(['--a.__proto__', 'IGNORED']);
+	t.deepEqual(argv.a, {});
+	t.end();
+});
+
+// Not pollution as such, but verify protections working as intended.
+test('trailing __proto__ in option key ignored', function (t) {
+	var argv = parse(['--a.constructor', 'IGNORED']);
+	t.deepEqual(argv.a, {});
+	t.end();
+});
+
 test('proto pollution', function (t) {
 	var argv = parse(['--__proto__.x', '123']);
 	t.equal({}.x, undefined);


### PR DESCRIPTION
There are separate checks against the leading keys in a dotted option name than against the last key. If the checks for `__proto__` or `constructor` are wrong in the checks of the last key then it won't lead to prototype pollution as such, but will lead to less consistent behaviour between `--a.constructor.prototype.b` and `--a.constructor`.

The pollution checks on the v0.2.x branch missed the `constructor` check on the last key in the dotted option name. So again this does not allow prototype pollution, but does mean there is different behaviour between the main branch and the v0.2.x branch.

This PR adds a test which fails due to the missing code, and the failing test will be fixed by #24. (Added separately so can see the test fail. Tests added high in the file to avoid a future merge conflict on mainline to slightly simplify copying up.)

If this seems worthwhile, this could be merged separately or as part of #24?

```
not ok 103 should be deeply equivalent
  ---
    operator: deepEqual
    expected: |-
      {}
    actual: |-
      { constructor: [ [Function: Object], 'IGNORED' ] }
    at: Test.<anonymous> (/Users/john/Documents/Sandpits/minimist/my-fork/test/proto.js:18:4)
```