### PR TITLE
Tests: remove redundant test

### DIFF
--- a/test/bool.js
+++ b/test/bool.js
@@ -38,27 +38,6 @@ test('boolean groups', function (t) {
 	t.deepEqual(typeof argv.z, 'boolean');
 	t.end();
 });
-test('boolean and alias with chainable api', function (t) {
-	var aliased = ['-h', 'derp'];
-	var regular = ['--herp', 'derp'];
-	var aliasedArgv = parse(aliased, {
-		boolean: 'herp',
-		alias: { h: 'herp' },
-	});
-	var propertyArgv = parse(regular, {
-		boolean: 'herp',
-		alias: { h: 'herp' },
-	});
-	var expected = {
-		herp: true,
-		h: true,
-		_: ['derp'],
-	};
-
-	t.same(aliasedArgv, expected);
-	t.same(propertyArgv, expected);
-	t.end();
-});
 
 test('boolean and alias with options hash', function (t) {
 	var aliased = ['-h', 'derp'];


### PR DESCRIPTION
Very unexciting. Remove duplicate test, the original intent of which is lost in the mists of time.

The non-functional custom code was already removed due to lint warnings. The remaining code in `boolean and alias with chainable api` is functionally the same as the following test `boolean and alias with options hash`.

Closes: #7