### PR TITLE
[patch]: include aliases when looking for defaults for booleans

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,13 @@ module.exports = function (args, opts) {
 
 	var aliases = {};
 
-	function aliasIsBoolean(key) {
+	function isBooleanKey(key) {
+		if (flags.bools[key]) {
+			return true;
+		}
+		if (!aliases[key]) {
+			return false;
+		}
 		return aliases[key].some(function (x) {
 			return flags.bools[x];
 		});
@@ -165,9 +171,8 @@ module.exports = function (args, opts) {
 			if (
 				next !== undefined
 				&& !(/^(-|--)[^-]/).test(next)
-				&& !flags.bools[key]
+				&& !isBooleanKey(key)
 				&& !flags.allBools
-				&& (aliases[key] ? !aliasIsBoolean(key) : true)
 			) {
 				setArg(key, next, arg);
 				i += 1;
@@ -218,8 +223,7 @@ module.exports = function (args, opts) {
 				if (
 					args[i + 1]
 					&& !(/^(-|--)[^-]/).test(args[i + 1])
-					&& !flags.bools[key]
-					&& (aliases[key] ? !aliasIsBoolean(key) : true)
+					&& !isBooleanKey(key)
 				) {
 					setArg(key, args[i + 1], arg);
 					i += 1;

--- a/index.js
+++ b/index.js
@@ -135,10 +135,14 @@ module.exports = function (args, opts) {
 		});
 	}
 
+	// Set booleans to false by default.
 	Object.keys(flags.bools).forEach(function (key) {
-		setArg(key, defaults[key] === undefined ? false : defaults[key]);
+		setArg(key, false);
 	});
-
+	// Set booleans to user defined default if supplied.
+	Object.keys(defaults).filter(isBooleanKey).forEach(function (key) {
+		setArg(key, defaults[key]);
+	});
 	var notFlags = [];
 
 	if (args.indexOf('--') !== -1) {

--- a/test/bool.js
+++ b/test/bool.js
@@ -154,3 +154,19 @@ test('boolean using something similar to true', function (t) {
 	t.same(result, expected);
 	t.end();
 });
+
+test('supplied default for boolean using alias', function (t) {
+	var argv = parse(['moo'], {
+		boolean: ['bool'],
+		alias: { bool: 'b' },
+		default: { b: true },
+	});
+
+	t.deepEqual(argv, {
+		bool: true,
+		b: true,
+		_: ['moo'],
+	});
+
+	t.end();
+});


### PR DESCRIPTION
The starting values for boolean options are applied before parsing, whether `false` or a user supplied default. The check for user supplied defaults was not including aliases. Keep it simple and do in two passes using same alias detection logic as in existing code.

Fixes: #29