### PR TITLE
[patch]: consider aliases when testing boolean option value against 'false'

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ module.exports = function (args, opts) {
 			var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
 			key = m[1];
 			var value = m[2];
-			if (flags.bools[key]) {
+			if (isBooleanKey(key)) {
 				value = value !== 'false';
 			}
 			setArg(key, value, arg);

--- a/test/bool.js
+++ b/test/bool.js
@@ -167,6 +167,18 @@ test('supplied default for boolean using alias', function (t) {
 		b: true,
 		_: ['moo'],
 	});
+	t.end();
+});
 
+test('boolean and alias --boool=false', function (t) {
+	var parsed = parse(['--boool=false'], {
+		default: {
+			b: true,
+		},
+		alias: { b: 'boool' },
+		boolean: ['b'],
+	});
+
+	t.same(parsed.boool, false);
 	t.end();
 });


### PR DESCRIPTION
Take aliases into consideration when processing value assigned to a boolean option, like `--dry-run=false`. See #30 for details.

Fixes: #30
