### PR TITLE
meta: extend FUNDING to list current github maintainers

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [ljharb]
+github: [ljharb, shadowspawn]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
Adding myself to FUNDING as another GitHub sponsor-enabled maintainer.

Side note: I have had more github sponsors this month than in the previous 3 years, so encouraged to update the listing as seems to be getting some use!