### PR TITLE
[readme]: document string positionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Return an argument object `argv` populated with the array arguments from `args`.
 them.
 
 Numeric-looking arguments will be returned as numbers unless `opts.string` or
-`opts.boolean` is set for that argument name.
+`opts.boolean` contains that argument name. To disable numeric conversion
+for non-option arguments, add `'_'` to `opts.string`.
 
 Any arguments after `'--'` will not be parsed and will end up in `argv._`.
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -93,12 +93,14 @@ test('strings', function (t) {
 });
 
 test('stringArgs', function (t) {
-	var s = parse(['  ', '  '], { string: '_' })._;
-	t.same(s.length, 2);
+	var s = parse(['  ', '  ', '3'], { string: '_' })._;
+	t.same(s.length, 3);
 	t.same(typeof s[0], 'string');
 	t.same(s[0], '  ');
 	t.same(typeof s[1], 'string');
 	t.same(s[1], '  ');
+	t.same(typeof s[2], 'string');
+	t.same(s[2], '3');
 	t.end();
 });
 


### PR DESCRIPTION
Add description of disabling numeric conversion for non-option arguments. This is a stealth feature which some clients are using.

Fixes: #52