### PR TITLE
readme: add description of ECMAScript

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,5 +25,9 @@
 				"camelcase": 0,
 			},
 		},
-	]
+		{
+			"files": "example/**",
+			"extends": "@ljharb/eslint-config/node/latest",
+		},
+	],
 }

--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ fanciful decoration.
 
 # example
 
+Example files: [example/parse.js](./example/parse.js) (CJS) / [example/parse.mjs](./example/parse.mjs) (ESM)
+
 ``` js
-var argv = require('minimist')(process.argv.slice(2));
+// for CJS
+const argv = require('minimist')(process.argv.slice(2));
+
+// for ESM
+// import minimist from 'minimist';
+// const argv = minimist(process.argv.slice(2));
 console.log(argv);
 ```
 
@@ -42,10 +49,11 @@ $ node example/parse.js -x 3 -y 4 -n5 -abc --beep=boop --no-ding foo bar baz
 # methods
 
 ``` js
-var parseArgs = require('minimist')
+const parseArgs = require('minimist');
 ```
 
-## var argv = parseArgs(args, opts={})
+<a name="var-argv--parseargsargs-opts"></a>
+## const argv = parseArgs(args, opts={})
 
 Return an argument object `argv` populated with the array arguments from `args`.
 

--- a/example/parse.js
+++ b/example/parse.js
@@ -1,4 +1,4 @@
 'use strict';
 
-var argv = require('../')(process.argv.slice(2));
+const argv = require('minimist')(process.argv.slice(2));
 console.log(argv);

--- a/example/parse.mjs
+++ b/example/parse.mjs
@@ -1,0 +1,4 @@
+import minimist from 'minimist';
+
+const argv = minimist(process.argv.slice(2));
+console.log(argv);


### PR DESCRIPTION
Added a description of ECMEScript to the readme and adjust the sample files to match.
### Issue
[Docs: Add sample code ES Modules format to the examples in the README\. · Issue \#61 · minimistjs/minimist](https://github.com/minimistjs/minimist/issues/61)