### PR TITLE
[New] Support for arrays in dotted notation (`--a.0.b`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,9 @@ module.exports = function (args, opts) {
 		for (var i = 0; i < keys.length - 1; i++) {
 			var key = keys[i];
 			if (isConstructorOrProto(o, key)) { return; }
-			if (o[key] === undefined) { o[key] = {}; }
+			if (o[key] === undefined) {
+				o[key] = (/^\d+$/).test(keys[i + 1]) ? [] : {};
+			}
 			if (
 				o[key] === Object.prototype
 				|| o[key] === Number.prototype

--- a/test/dotted.js
+++ b/test/dotted.js
@@ -25,12 +25,8 @@ test('dotted default with no alias', function (t) {
 
 test('dotted array', function (t) {
 	var argv = parse(['--a.1.foo', '11']);
-
-	t.notOk(Array.isArray(argv.a));
-
-	t.notOk(0 in argv.a);
-
+	t.true(Array.isArray(argv.a));
+	t.false(0 in argv.a);
 	t.equal(argv.a[1].foo, 11);
-
 	t.end();
 });


### PR DESCRIPTION
I'd like to suggest a feature that seems to be missing: Support for arrays in dotted notation.

Let me explain the feature request using this simple example:
```sh
$ echo "console.log(require('minimist')(['--foo.0.bar=x', '--foo.2.bar=42']))" | node
```

#### Actual behavior
```javascript
{ _: [], foo: { '0': { bar: 'x' }, '2': { bar: 42 } } }
```

#### Desired behavior
```javascript
{ _: [], foo: [ { bar: 'x' }, <1 empty item>, { bar: 42 } ] }
```

#### Motivation
I'd like to use program args as alternative or optional addon to a configuration file. In my concrete use case, I read a YAML configuration and merge it with the values from command line args. Minimist supports this greatly for anything except arrays (lists).

#### Comments
Please tell if you think this feature could be useful. I apologize for this minimal PR with a single test and no documentation. I'd like to discuss the feature before putting more work into it.

All tests are still green, but since this feature is not fully backwards compatible, we could enforce to enable it explicitely by a config option. If you agree, please advise on how to implement that (javascript is not one of my native languages).