### PR TITLE
[New] Support for arrays in dotted notation (`--a[1].b`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function isConstructorOrProto(obj, key) {
 
 function resolveArrays(o, key) {
 	var ARRAY = RegExp(/^([^[]+)\[([^\]]+)\](.*)/);
-	var groups = ARRAY.exec(key);
-	while (groups) {
+	var groups;
+	while ((groups = ARRAY.exec(key))) {
 		var arr = groups[1];
 		var idx = groups[2];
 		var rest = groups[3];
@@ -32,7 +32,6 @@ function resolveArrays(o, key) {
 		}
 		o = o[arr];
 		key = idx + (rest || '');
-		groups = ARRAY.exec(key);
 	}
 	return [o, key];
 }

--- a/test/dotted.js
+++ b/test/dotted.js
@@ -34,3 +34,14 @@ test('dotted array', function (t) {
 
 	t.end();
 });
+
+test('dotted notation with array in square bracket syntax', function (t) {
+	var argv = parse(['--a[1][0].foo', 'x', '--a[1][2]', '42']);
+	t.ok(Array.isArray(argv.a));
+	t.notOk(0 in argv.a);
+	t.ok(Array.isArray(argv.a[1]));
+	t.equal(argv.a[1][0].foo, 'x');
+	t.notOk(1 in argv.a[1]);
+	t.equal(argv.a[1][2].foo, 42);
+	t.end();
+});


### PR DESCRIPTION
I'd like to suggest a feature that seems to be missing: Support for arrays in dotted notation.

Let me explain the feature request using this simple example:

```sh
$ echo "console.log(require('minimist')(['--foo[0].bar=x', '--foo[2].bar=42']))" | node
```

#### Actual behavior

```javascript
{ _: [], 'foo[0]': { bar: 'x' }, 'foo[2]': { bar: 42 } }
```

#### Desired behavior

```javascript
{ _: [], foo: [ { bar: 'x' }, <1 empty item>, { bar: 42 } ] }
```

#### Motivation
#66 is a request for the same feature using a different syntax `foo.0.bar`. That syntax may be used to reference an array and may be implemented using a one-liner, but is unusual. This PR adapts to the well-known square bracket syntax and allows to discuss each idea on its own.
