### PR TITLE
chore: specify files field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "1.2.8",
 	"description": "parse argument options",
 	"main": "index.js",
+	"files": [
+		"index.js"
+	],
 	"devDependencies": {
 		"@ljharb/eslint-config": "^21.1.1",
 		"aud": "^2.0.4",


### PR DESCRIPTION
currently the install size is 53.2kB https://packagephobia.com/result?p=minimist

The size is unnecessarily large because the test files, examples and CHANGELOG are all published to npm. This patch will set the files field in package.json to only include the necessary files when publishing. It should reduce the install size to around 12kB 

<img width="828" alt="image" src="https://github.com/user-attachments/assets/0714808e-5f3f-4e48-a56e-74add96fcc6f" />
