### PR TITLE
[meta] Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 	"description": "parse argument options",
 	"main": "index.js",
 	"scripts": {
-		"prepack": "npmignore --auto --commentLines=auto",
 		"prepublishOnly": "safe-publish-latest",
 		"prepublish": "not-in-publish || npm run prepublishOnly",
 		"lint": "eslint --ext=js,mjs .",
@@ -15,6 +14,9 @@
 		"version": "auto-changelog && git add CHANGELOG.md",
 		"postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
 	},
+	"files": [
+		"index.js"
+	],
 	"testling": {
 		"files": "test/*.js"
 	},
@@ -44,7 +46,6 @@
 		"encoding": "^0.1.13",
 		"eslint": "=8.8.0",
 		"in-publish": "^2.0.1",
-		"npmignore": "^0.3.1",
 		"nyc": "^10.3.2",
 		"safe-publish-latest": "^2.0.0",
 		"tape": "^5.9.0"
@@ -59,10 +60,5 @@
 		"commitLimit": false,
 		"backfillLimit": false,
 		"hideCredit": true
-	},
-	"publishConfig": {
-		"ignore": [
-			".github/workflows"
-		]
 	}
 }


### PR DESCRIPTION
This change leads to a ~3x reduction in package size, and ~5x reduction in on-disk size via using https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files

I noticed minimist 1.2.8 looked larger than necessary in node_modules:

<img width="260" alt="Screenshot 2025-02-04 at 12 39 47" src="https://github.com/user-attachments/assets/7a268bed-e34c-4bd2-9b59-5bfc5838cfaf" />

## Context

Before this change, the [`npmignore`](https://www.npmjs.com/package/npmignore) package was used to generate a `.npmignore` file from the `.gitignore` of the repo.

The files that this misses are below, and an allowlist approach seemed more maintainable, given `index.js` is the only file you use.

Change introducing this: https://github.com/minimistjs/minimist/commit/f81ece6aaec2fa14e69ff4f1e0407a8c4e2635a2

## Change

* revert https://github.com/minimistjs/minimist/commit/f81ece6aaec2fa14e69ff4f1e0407a8c4e2635a2
* add `files` key: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files
  * Note that the listing of `index.js` is not necessary, as it is implicitly included due to the `main` key

Removes:
* .github/
* example/
* test/
* .eslintrc
* .nycrc
* CHANGELOG.md
  * Some people online say that this would still be included. The output of `npm pack --dry-run` disagrees

## Testing

```
npm pack --dry-run
```

**Before**

note: output changed a little since making the commit message

```
npm notice === Tarball Contents === 
npm notice 598B   .eslintrc             
npm notice 592B   .github/FUNDING.yml   
npm notice 229B   .nycrc                
npm notice 22.1kB CHANGELOG.md          
npm notice 1.1kB  LICENSE               
npm notice 3.8kB  README.md             
npm notice 91B    example/parse.js      
npm notice 99B    example/parse.mjs     
npm notice 6.3kB  index.js              
npm notice 1.7kB  package.json          
npm notice 1.0kB  test/all_bool.js      
npm notice 2.4kB  test/array.js         
npm notice 3.6kB  test/bool.js          
npm notice 1.2kB  test/dash.js          
npm notice 713B   test/default_bool.js  
npm notice 766B   test/dotted.js        
npm notice 660B   test/kv_short.js      
npm notice 649B   test/long.js          
npm notice 792B   test/num.js           
npm notice 237B   test/parse_modified.js
npm notice 4.1kB  test/parse.js         
npm notice 2.2kB  test/proto.js         
npm notice 1.3kB  test/short.js         
npm notice 312B   test/stop_early.js    
npm notice 2.1kB  test/unknown.js       
npm notice 194B   test/whitespace.js    
npm notice === Tarball Details === 
npm notice name:          minimist                                
npm notice version:       1.2.8                                   
npm notice filename:      minimist-1.2.8.tgz                      
npm notice package size:  16.6 kB                                 
npm notice unpacked size: 59.0 kB                                 
npm notice shasum:        832f0fdc2f2fa34eae9f83aeaf4915251605ce76
npm notice integrity:     sha512-PxfINY93zIY6y[...]h9nt9UIkIOm9A==
npm notice total files:   26     
```

**After**

```
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 3.8kB README.md   
npm notice 6.3kB index.js    
npm notice 1.6kB package.json
npm notice === Tarball Details === 
npm notice name:          minimist                                
npm notice version:       1.2.8
npm notice filename:      minimist-1.2.8.tgz
npm notice package size:  4.9 kB
npm notice unpacked size: 12.9 kB
npm notice shasum:        4a3e9fcc22cc0dd250705d0991913dd4b414a062
npm notice integrity:     sha512-6N2v+Q/KAOLab[...]W8lvhg4jUI69A==
npm notice total files:   4
```