### PR TITLE
Fix broken repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/minimistjs/minimist.git"
+		"url": "git+ssh://github.com/minimistjs/minimist.git"
 	},
 	"homepage": "https://github.com/minimistjs/minimist",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/minimistjs/minimist.git"
+		"url": "https://github.com/minimistjs/minimist.git"
 	},
 	"homepage": "https://github.com/minimistjs/minimist",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://github.com/minimistjs/minimist.git"
+		"url": "ssh://github.com/minimistjs/minimist.git"
 	},
 	"homepage": "https://github.com/minimistjs/minimist",
 	"keywords": [


### PR DESCRIPTION
GitHub hasn't supported the git protocol [since 2022](https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git), so this URL is broken.

(This is a common error affecting many popular npm packages; I'm opening PRs on several projects to fix it. I encourage anyone reading this to check any packages they maintain and implement the same fix if appropriate!)